### PR TITLE
docs: add workaround for oh-my-opencode agent config issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We highly recommend pinning the `@conductor` agent to a "flash" model for optima
 
 ### OhMyOpenCode Config
 
-> **⚠️ Important:** Due to current OpenCode limitations, you need to configure the conductor agent in **both** config files when using oh-my-opencode.
+> **⚠️ Important:** Due to current OpenCode limitations, you need to configure the conductor agent in **both** config files when using oh-my-opencode. Additionally, the conductor agent must have the `task` tool enabled to delegate work to other agents like Sisyphus.
 
 **File:** `~/.config/opencode/opencode.json`
 ```json
@@ -87,7 +87,10 @@ We highly recommend pinning the `@conductor` agent to a "flash" model for optima
   ],
   "agent": {
     "conductor": {
-      "model": "google/gemini-3-flash"
+      "model": "google/gemini-3-flash",
+      "tools": {
+        "task": true
+      }
     }
   }
 }
@@ -98,13 +101,16 @@ We highly recommend pinning the `@conductor` agent to a "flash" model for optima
 {
   "agents": {
     "conductor": {
-      "model": "google/gemini-3-flash"
+      "model": "google/gemini-3-flash",
+      "tools": {
+        "task": true
+      }
     }
   }
 }
 ```
 
-*Note: The key difference is `"agent"` (singular) in `opencode.json` vs `"agents"` (plural) in `oh-my-opencode.json`. See [Issue #3](https://github.com/derekbar90/opencode-conductor/issues/3) for details.*
+*Note: The key difference is `"agent"` (singular) in `opencode.json` vs `"agents"` (plural) in `oh-my-opencode.json`. The `task` tool is required for conductor to delegate implementation work to Sisyphus and other oh-my-opencode agents. See [Issue #3](https://github.com/derekbar90/opencode-conductor/issues/3) for details.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ We highly recommend pinning the `@conductor` agent to a "flash" model for optima
 ```
 
 ### OhMyOpenCode Config
+
+> **⚠️ Important:** Due to current OpenCode limitations, you need to configure the conductor agent in **both** config files when using oh-my-opencode.
+
+**File:** `~/.config/opencode/opencode.json`
+```json
+{
+  "plugin": [
+    "oh-my-opencode@latest",
+    "opencode-conductor-plugin@latest"
+  ],
+  "agent": {
+    "conductor": {
+      "model": "google/gemini-3-flash"
+    }
+  }
+}
+```
+
 **File:** `~/.config/opencode/oh-my-opencode.json`
 ```json
 {
@@ -85,6 +103,8 @@ We highly recommend pinning the `@conductor` agent to a "flash" model for optima
   }
 }
 ```
+
+*Note: The key difference is `"agent"` (singular) in `opencode.json` vs `"agents"` (plural) in `oh-my-opencode.json`. See [Issue #3](https://github.com/derekbar90/opencode-conductor/issues/3) for details.*
 
 ---
 


### PR DESCRIPTION
## Summary

- Documents workaround for agent configuration with oh-my-opencode
- Adds warning about needing config in both files
- References #3 for tracking the underlying issue

## Problem

When using oh-my-opencode with conductor, agent configuration in `oh-my-opencode.json` alone doesn't work due to OpenCode core limitations (see investigation in #3).

## Solution

Update README to document the current workaround: configure the conductor agent in **both** `opencode.json` and `oh-my-opencode.json`.

## Changes

- Added warning callout in OhMyOpenCode Config section
- Added example showing configuration in both files
- Added note explaining key name differences (`agent` vs `agents`)
- Linked to #3 for more details

Relates to #3