### PR TITLE
fix: improve OMO detection and update task delegation

### DIFF
--- a/src/commands/implement.ts
+++ b/src/commands/implement.ts
@@ -1,5 +1,6 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import { existsSync } from "fs";
+import { readFile } from "fs/promises";
 import { join } from "path";
 import { loadPrompt } from "../utils/promptLoader.js";
 

--- a/src/prompts/strategies/delegate.md
+++ b/src/prompts/strategies/delegate.md
@@ -2,10 +2,24 @@
 You are acting as the **Architect**. Your responsibility is to oversee the track while delegating execution to **Sisyphus**.
 
 **DIRECTIVE:**
-1.  **Do NOT implement code yourself.**
-2.  **Delegate:** For each task in `plan.md`, call `@sisyphus`.
-    *   *Note:* The system will automatically inject the full project context for you.
-    *   *Instruction:* Tell Sisyphus: "Execute this task. You have authority to update `plan.md` if needed. Report 'PLAN_UPDATED' if you do."
+1.  **Do NOT implement code yourself.** You are the planner, not the implementer.
+2.  **Delegate using the `task` tool:** For each task in `plan.md`, use the `task` tool to delegate implementation to Sisyphus.
+    
+    **How to delegate:**
+    ```
+    task(
+      description: "[Brief task description from plan]",
+      prompt: "Execute this task: [FULL TASK DETAILS FROM PLAN]. You have authority to update plan.md if needed. Report 'PLAN_UPDATED' if you modify the plan.",
+      subagent_type: "local-implement-subagent"
+    )
+    ```
+    
+    *   The system will automatically inject the Conductor context (workflow, protocol) to the subagent.
+    *   Wait for each task to complete before proceeding to the next one.
+    *   Each task creates a visible subtask session.
+
 3.  **Verify:**
-    *   If Sisyphus reports 'PLAN_UPDATED', you MUST **reload** `plan.md` before the next task.
+    *   If the subagent reports 'PLAN_UPDATED', you MUST **reload** `plan.md` before the next task.
     *   If success, verify against the plan and proceed to the next task.
+
+**IMPORTANT:** Use `task` tool for implementation work. Do NOT implement code yourself.


### PR DESCRIPTION
## Summary

This PR fixes the oh-my-opencode (OMO) detection logic and updates task delegation to work properly with the current OpenCode plugin system.

## Problem

The OMO detection was failing because it only checked `~/.config/opencode/` for plugin installation, but OpenCode actually installs plugins at runtime in `~/.cache/opencode/node_modules/`. This caused "OMO Synergy: Disabled" to appear even when oh-my-opencode was properly installed.

## Changes

### 1. Improved OMO Detection (`src/index.ts`)
Added a robust `detectOMO()` function with 3 fallback methods:
1. **Primary**: Check `~/.cache/opencode/node_modules/oh-my-opencode` (runtime plugin location)
2. **Fallback 1**: Check `opencode.json` config plugin array
3. **Fallback 2**: Check if `oh-my-opencode.json` config file exists

### 2. Updated Task Delegation Hook
- Changed from deprecated `delegate_to_agent` tool to `task` tool
- Updated interception logic to match `subagent_type` parameter
- Now intercepts delegation to `implement`, `general`, or `sisyphus` subagents

### 3. Updated Delegation Strategy (`src/prompts/strategies/delegate.md`)
- Added clear instructions on how to use the `task` tool for delegation
- Included example code snippet for proper task delegation

## Testing

Verified locally that:
- `detectOMO()` correctly returns `true` when oh-my-opencode is installed
- The plugin reports "OMO Synergy: Enabled" on startup
- Task delegation interception works with the new tool name